### PR TITLE
Fix missing email credentials

### DIFF
--- a/Auto_Task_AI/.env
+++ b/Auto_Task_AI/.env
@@ -9,3 +9,11 @@ JWT_SECRET=your_jwt_secret
 TWILIO_ACCOUNT_SID=AC5671eab2506fc99a5ea7bbf2b1c77ce2
 TWILIO_AUTH_TOKEN=dbd0a0cb60e27b621ad8fe465e5a8240
 TWILIO_PHONE_NUMBER=6351913366
+
+# Email Configuration (SMTP)
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USER=your-email@gmail.com
+SMTP_PASS=your-app-password
+SMTP_SECURE=false
+SMTP_FROM=your-email@gmail.com

--- a/Backend/.env
+++ b/Backend/.env
@@ -9,3 +9,11 @@ JWT_SECRET=your_jwt_secret
 TWILIO_ACCOUNT_SID=AC5671eab2506fc99a5ea7bbf2b1c77ce2
 TWILIO_AUTH_TOKEN=dbd0a0cb60e27b621ad8fe465e5a8240
 TWILIO_PHONE_NUMBER=6351913366
+
+# Email Configuration (SMTP)
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USER=your-email@gmail.com
+SMTP_PASS=your-app-password
+SMTP_SECURE=false
+SMTP_FROM=your-email@gmail.com


### PR DESCRIPTION
Add SMTP email configuration to `.env` files to resolve missing credentials error for email service initialization.

---
<a href="https://cursor.com/background-agent?bcId=bc-ab075f69-332b-41ba-8808-f522d90ec3c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ab075f69-332b-41ba-8808-f522d90ec3c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

